### PR TITLE
Separate configurable settings out of config.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you need additional help, there is a [How-To video](http://www.oraopensource.
   <tr>
     <td>APEX</td>
     <td>5.0.0.00.31</td>
-    <td>Currently supports APEX 5.x and APEX 4.x releases. Just reference the appropriate file in config.sh</td>
+    <td>Currently supports APEX 5.x and APEX 4.x releases. Just reference the appropriate file in config.properties</td>
   </tr>
   <tr>
     <td>ORDS</td>
@@ -122,7 +122,7 @@ cd oraclexe-apex
 ```
 
 ###Vagrant
-Run the following on your host machine *(you will need `git` installed on your host machine)*: 
+Run the following on your host machine *(you will need `git` installed on your host machine)*:
 
 ```bash
 git clone https://github.com/OraOpenSource/oraclexe-apex.git
@@ -131,7 +131,7 @@ cd oraclexe-apex
 
 ## Configure
 
-*If doing a Vagrant install can modify `config.sh` in your local text editor.*
+*If doing a Vagrant install can modify `config.properties` in your local text editor.*
 
 ```bash
 #Look for "CHANGEME" in this file
@@ -139,7 +139,7 @@ cd oraclexe-apex
 #Type:<esc key>?CHANGEME   to search for CHANGEME
 #Once done modifying an entry, hit <esc> and type: n  to search for next entry
 #Read below for help on modifying this file
-vi config.sh
+vi config.properties
 ```
 
 ### Files
@@ -188,7 +188,7 @@ OOS_ORACLE_FILE_URL=file:///vagrant/files/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
 ```
 
 ### Modules
-You can optionally chose which modules you want installed. This install supports the following optional modules which can be modified in ```config.sh```
+You can optionally chose which modules you want installed. This install supports the following optional modules which can be modified in ```config.properties```
 
 <table>
   <tr>
@@ -389,7 +389,7 @@ The default port settings are as follows:
   </tr>
 </table>
 
-Open Optional ports can be configured in`config.sh` in the `FIREWALL` section. If you want to modify the firewall settings after running the build script, open `scripts/firewalld.sh` and look for examples on how to open (both temporarily and permanently).
+Open Optional ports can be configured in`config.properties` in the `FIREWALL` section. If you want to modify the firewall settings after running the build script, open `scripts/firewalld.sh` and look for examples on how to open (both temporarily and permanently).
 
 ## Vagrant Port Mapping
 The following ports are mapped to the host and can be configured in [Vagrantfile](Vagrantfile):

--- a/config.properties
+++ b/config.properties
@@ -57,9 +57,7 @@ OOS_ORDS_USERNAME=adminlistener
 OOS_ORDS_PASSWORD=oracle
 
 #TOMCAT config
-#Note: If not a tar.gz then remove the additional ".*" in OOS_TC_NAME
 OOS_TC_FILE_URL=https://s3-us-west-2.amazonaws.com/orclfiles/apache-tomcat-7.0.57.tar.gz
-
 OOS_TC_USERNAME=tomcat
 OOS_TC_PWD=oracle
 

--- a/config.properties
+++ b/config.properties
@@ -1,0 +1,72 @@
+OOS_MODULE_ORACLE=Y
+#APEX=APEX, Tomcat, ORDS
+OOS_MODULE_APEX=Y
+OOS_MODULE_NODE4ORDS=Y
+OOS_MODULE_NODE_ORACLEDB=Y
+
+OOS_ORACLE_PWD=oracle
+#Use 8081 so no conflicts with Tomcat. This is configured for plsql gateway (not used)
+OOS_ORACLE_HTTP_PORT=8081
+OOS_ORACLE_TNS_PORT=1521
+
+#URL to download Oracle XE rpm from
+#Ex: http://<server_name>/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+#To download go to: http://www.oracle.com/technetwork/database/database-technologies/express-edition/overview/index.html
+#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
+OOS_ORACLE_FILE_URL=CHANGEME
+
+#Create Oracle and APEX User (optional)
+#If Change to "N" to disable creating default Oracle User
+OOS_ORACLE_CREATE_USER_YN=Y
+#Create the default emp and dept tables
+OOS_ORACLE_CREATE_USER_DEMO_DATA_YN=Y
+OOS_ORACLE_USER_NAME=oos_user
+OOS_ORACLE_USER_PASS=oracle
+OOS_APEX_CREATE_USER_YN=Y
+OOS_APEX_USER_WORKSPACE=oos_user
+OOS_APEX_USER_NAME=oos_user
+OOS_APEX_USER_PASS=oracle
+
+#APEX Configs
+#URL to download APEX from
+#Ex: http://<server_name>/apex_4.2.6_en.zip
+#To download go to: http://download.oracleapex.com
+#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
+OOS_APEX_FILE_URL=CHANGEME
+
+#Note: APEX admin password has rules associated with it, which is why it is a more complicated password
+#Note: If deploying through Vagrant, please do not change the passwords below. You may do so after provisioning has completed.
+OOS_APEX_ADMIN_USER_NAME=admin
+OOS_APEX_ADMIN_EMAIL=admin@domain.com
+OOS_APEX_ADMIN_PWD=Oracle1!
+OOS_APEX_PUB_USR_PWD=oracle
+
+#APEX REST
+OOS_APEX_LISTENERUN_PWD=oracle
+OOS_APEX_REST_PUB_USR_PWD=oracle
+
+#ORDS
+#File for Oracle Rest Data Services (ORDS) download
+#Ex: http://<server_name>/ords.3.0.0.343.07.58.zip
+#To download go to: http://www.oracle.com/technetwork/developer-tools/rest-data-services/overview/index.html
+#Note, for now ORDS 2 is in production. ORDS 3 specific scripts have also been included and need to be finalized once its out of beta
+#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
+OOS_ORDS_FILE_URL=CHANGEME
+
+OOS_ORDS_USERNAME=adminlistener
+OOS_ORDS_PASSWORD=oracle
+
+#TOMCAT config
+#Note: If not a tar.gz then remove the additional ".*" in OOS_TC_NAME
+OOS_TC_FILE_URL=https://s3-us-west-2.amazonaws.com/orclfiles/apache-tomcat-7.0.57.tar.gz
+
+OOS_TC_USERNAME=tomcat
+OOS_TC_PWD=oracle
+
+#FIREWALL Config
+#Change these to Y to allow public access to their ports
+OOS_FIREWALL_TOMCAT_YN=N
+OOS_FIREWALL_ORACLE_YN=N
+
+#RLWRAP: https://github.com/hanslub42/rlwrap
+OOS_RLWRAP_FILENAME=rlwrap-0.42.tar.gz

--- a/config.properties
+++ b/config.properties
@@ -2,8 +2,17 @@
 # YN: should have Y or N as their value
 # FILE_URL: Can be a web link e.g http://myserver.com/file.zip; or a file path e.g. file:///tmp/file.zip
 
+#To download Oracle XE, go to: http://www.oracle.com/technetwork/database/database-technologies/express-edition/overview/index.html
+OOS_ORACLE_FILE_URL=CHANGEME
+
+#To download APEX, go to: http://download.oracleapex.com
+OOS_APEX_FILE_URL=CHANGEME
+
+#To download ORDS, go to: http://www.oracle.com/technetwork/developer-tools/rest-data-services/overview/index.html
+#Note, for now ORDS 2 is in production. ORDS 3 specific scripts have also been included and need to be finalized once its out of beta
+OOS_ORDS_FILE_URL=CHANGEME
+
 OOS_MODULE_ORACLE=Y
-#APEX will install APEX, Tomcat and ORDS
 OOS_MODULE_APEX=Y
 OOS_MODULE_NODE4ORDS=Y
 OOS_MODULE_NODE_ORACLEDB=Y
@@ -13,9 +22,6 @@ OOS_ORACLE_PWD=oracle
 #Use 8081 so no conflicts with Tomcat. This is configured for plsql gateway (not used)
 OOS_ORACLE_HTTP_PORT=8081
 OOS_ORACLE_TNS_PORT=1521
-
-#To download go to: http://www.oracle.com/technetwork/database/database-technologies/express-edition/overview/index.html
-OOS_ORACLE_FILE_URL=CHANGEME
 
 #Create Oracle and APEX User (optional)
 #If Change to "N" to disable creating default Oracle User
@@ -28,9 +34,6 @@ OOS_APEX_CREATE_USER_YN=Y
 OOS_APEX_USER_WORKSPACE=oos_user
 OOS_APEX_USER_NAME=oos_user
 OOS_APEX_USER_PASS=oracle
-
-#To download go to: http://download.oracleapex.com
-OOS_APEX_FILE_URL=CHANGEME
 
 OOS_APEX_ADMIN_USER_NAME=admin
 OOS_APEX_ADMIN_EMAIL=admin@domain.com
@@ -45,10 +48,6 @@ OOS_APEX_LISTENERUN_PWD=oracle
 OOS_APEX_REST_PUB_USR_PWD=oracle
 
 #ORDS
-
-#To download go to: http://www.oracle.com/technetwork/developer-tools/rest-data-services/overview/index.html
-#Note, for now ORDS 2 is in production. ORDS 3 specific scripts have also been included and need to be finalized once its out of beta
-OOS_ORDS_FILE_URL=CHANGEME
 OOS_ORDS_USERNAME=adminlistener
 OOS_ORDS_PASSWORD=oracle
 

--- a/config.properties
+++ b/config.properties
@@ -1,18 +1,20 @@
+#Properties ending with
+# YN: should have Y or N as their value
+# FILE_URL: Can be a web link e.g http://myserver.com/file.zip; or a file path e.g. file:///tmp/file.zip
+
 OOS_MODULE_ORACLE=Y
-#APEX=APEX, Tomcat, ORDS
+#APEX will install APEX, Tomcat and ORDS
 OOS_MODULE_APEX=Y
 OOS_MODULE_NODE4ORDS=Y
 OOS_MODULE_NODE_ORACLEDB=Y
 
+#ORACLE Database module properties
 OOS_ORACLE_PWD=oracle
 #Use 8081 so no conflicts with Tomcat. This is configured for plsql gateway (not used)
 OOS_ORACLE_HTTP_PORT=8081
 OOS_ORACLE_TNS_PORT=1521
 
-#URL to download Oracle XE rpm from
-#Ex: http://<server_name>/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
 #To download go to: http://www.oracle.com/technetwork/database/database-technologies/express-edition/overview/index.html
-#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
 OOS_ORACLE_FILE_URL=CHANGEME
 
 #Create Oracle and APEX User (optional)
@@ -27,17 +29,14 @@ OOS_APEX_USER_WORKSPACE=oos_user
 OOS_APEX_USER_NAME=oos_user
 OOS_APEX_USER_PASS=oracle
 
-#APEX Configs
-#URL to download APEX from
-#Ex: http://<server_name>/apex_4.2.6_en.zip
 #To download go to: http://download.oracleapex.com
-#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
 OOS_APEX_FILE_URL=CHANGEME
 
-#Note: APEX admin password has rules associated with it, which is why it is a more complicated password
-#Note: If deploying through Vagrant, please do not change the passwords below. You may do so after provisioning has completed.
 OOS_APEX_ADMIN_USER_NAME=admin
 OOS_APEX_ADMIN_EMAIL=admin@domain.com
+
+#If using Vagrant, do not change until after install
+#ADMIN_PWD more complex than standard 'oracle' due to complexity requirements
 OOS_APEX_ADMIN_PWD=Oracle1!
 OOS_APEX_PUB_USR_PWD=oracle
 
@@ -46,13 +45,10 @@ OOS_APEX_LISTENERUN_PWD=oracle
 OOS_APEX_REST_PUB_USR_PWD=oracle
 
 #ORDS
-#File for Oracle Rest Data Services (ORDS) download
-#Ex: http://<server_name>/ords.3.0.0.343.07.58.zip
+
 #To download go to: http://www.oracle.com/technetwork/developer-tools/rest-data-services/overview/index.html
 #Note, for now ORDS 2 is in production. ORDS 3 specific scripts have also been included and need to be finalized once its out of beta
-#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
 OOS_ORDS_FILE_URL=CHANGEME
-
 OOS_ORDS_USERNAME=adminlistener
 OOS_ORDS_PASSWORD=oracle
 
@@ -62,7 +58,7 @@ OOS_TC_USERNAME=tomcat
 OOS_TC_PWD=oracle
 
 #FIREWALL Config
-#Change these to Y to allow public access to their ports
+#Y=Port open;N=Port closed
 OOS_FIREWALL_TOMCAT_YN=N
 OOS_FIREWALL_ORACLE_YN=N
 

--- a/config.sh
+++ b/config.sh
@@ -5,11 +5,11 @@ source config.properties
 
 if [ "$OOS_MODULE_APEX" = "N" ]; then
   OOS_MODULE_ORDS=N;
-  OOS_MODULE_TOMCAT=N;  
-  OOS_MODULE_NODE4ORDS=N;  
+  OOS_MODULE_TOMCAT=N;
+  OOS_MODULE_NODE4ORDS=N;
 else
   OOS_MODULE_ORDS=Y;
-  OOS_MODULE_TOMCAT=Y;  
+  OOS_MODULE_TOMCAT=Y;
 fi;
 
 #Always install Node.js
@@ -34,8 +34,18 @@ OOS_ORACLE_FILENAME_RPM=${OOS_ORACLE_FILENAME%.*}
 OOS_APEX_ZIP_FILENAME=${OOS_APEX_FILE_URL##*/}
 OOS_ORDS_FILENAME=${OOS_ORDS_FILE_URL##*/}
 OOS_TC_FILENAME=${OOS_TC_FILE_URL##*/}
-OOS_TC_NAME=${OOS_TC_FILENAME%.*.*}
+
 OOS_RLWRAP_NAME=${OOS_RLWRAP_FILENAME%.*.*}
+
+#Get the filename excluding the extension
+if [[ ${OOS_TC_FILENAME} == *.tar.gz ]]; then
+  OOS_TC_NAME=${OOS_TC_FILENAME%.*.*}
+else
+  OOS_TC_NAME=${OOS_TC_FILENAME%.*}
+fi
+
+echo T0: $OOS_TC_FILE_URL
+echo T1: $OOS_TC_NAME
 
 #Call Validations
 source ./scripts/config_validation.sh

--- a/config.sh
+++ b/config.sh
@@ -1,34 +1,20 @@
 #!/usr/bin/env bash
 #Example from: http://stackoverflow.com/questions/5228345/bash-script-how-to-reference-a-file-for-variables
 
-#Module Options (Y/N)
-#CHANGEME (for the modules below)
+source config.properties
 
-#Added as part of #11
-OOS_MODULE_ORACLE=Y
-#APEX=APEX, Tomcat, ORDS
-OOS_MODULE_APEX=Y
-
-#DO NOT modify these modules
-OOS_MODULE_ORDS=Y
 if [ "$OOS_MODULE_APEX" = "N" ]; then
   OOS_MODULE_ORDS=N;
-fi;
-
-OOS_MODULE_TOMCAT=Y
-if [ "$OOS_MODULE_APEX" = "N" ]; then
-  OOS_MODULE_TOMCAT=N;
+  OOS_MODULE_TOMCAT=N;  
+  OOS_MODULE_NODE4ORDS=N;  
+else
+  OOS_MODULE_ORDS=Y;
+  OOS_MODULE_TOMCAT=Y;  
 fi;
 
 #Always install Node.js
 OOS_MODULE_NODEJS=Y
 
-OOS_MODULE_NODE4ORDS=Y
-if [ "$OOS_MODULE_APEX" = "N" ]; then
-  OOS_MODULE_NODE4ORDS=N;
-fi;
-
-OOS_MODULE_NODE_ORACLEDB=Y
 if [ "$OOS_MODULE_ORACLE" = "N" ]; then
   OOS_MODULE_NODE_ORACLEDB=N;
 fi;
@@ -43,82 +29,12 @@ echo Node4ORDS: $OOS_MODULE_NODE4ORDS
 echo Node.js: $OOS_MODULE_NODEJS
 echo Node-oracledb: $OOS_MODULE_NODE_ORACLEDB
 
-#System
-
-#Oracle
-OOS_ORACLE_PWD=oracle
-#Use 8081 so no conflicts with Tomcat. This is configured for plsql gateway (not used)
-OOS_ORACLE_HTTP_PORT=8081
-OOS_ORACLE_TNS_PORT=1521
-
-#URL to download Oracle XE rpm from
-#Ex: http://<server_name>/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
-#To download go to: http://www.oracle.com/technetwork/database/database-technologies/express-edition/overview/index.html
-#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
-OOS_ORACLE_FILE_URL=CHANGEME
 OOS_ORACLE_FILENAME=${OOS_ORACLE_FILE_URL##*/}
 OOS_ORACLE_FILENAME_RPM=${OOS_ORACLE_FILENAME%.*}
-
-#Create Oracle and APEX User (optional)
-#If Change to "N" to disable creating default Oracle User
-OOS_ORACLE_CREATE_USER_YN=Y
-#Create the default emp and dept tables
-OOS_ORACLE_CREATE_USER_DEMO_DATA_YN=Y
-OOS_ORACLE_USER_NAME=oos_user
-OOS_ORACLE_USER_PASS=oracle
-OOS_APEX_CREATE_USER_YN=Y
-OOS_APEX_USER_WORKSPACE=oos_user
-OOS_APEX_USER_NAME=oos_user
-OOS_APEX_USER_PASS=oracle
-
-#APEX Configs
-#URL to download APEX from
-#Ex: http://<server_name>/apex_4.2.6_en.zip
-#To download go to: http://download.oracleapex.com
-#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
-OOS_APEX_FILE_URL=CHANGEME
 OOS_APEX_ZIP_FILENAME=${OOS_APEX_FILE_URL##*/}
-#Note: APEX admin password has rules associated with it, which is why it is a more complicated password
-#Note: If deploying through Vagrant, please do not change the passwords below. You may do so after provisioning has completed.
-OOS_APEX_ADMIN_USER_NAME=admin
-OOS_APEX_ADMIN_EMAIL=admin@domain.com
-OOS_APEX_ADMIN_PWD=Oracle1!
-OOS_APEX_PUB_USR_PWD=oracle
-
-#APEX REST
-OOS_APEX_LISTENERUN_PWD=oracle
-OOS_APEX_REST_PUB_USR_PWD=oracle
-
-#ORDS
-#File for Oracle Rest Data Services (ORDS) download
-#Ex: http://<server_name>/ords.3.0.0.343.07.58.zip
-#To download go to: http://www.oracle.com/technetwork/developer-tools/rest-data-services/overview/index.html
-#Note, for now ORDS 2 is in production. ORDS 3 specific scripts have also been included and need to be finalized once its out of beta
-#Can be url (like http://myserver.com/file.zip) or file reference (file:///tmp/file.zip)
-OOS_ORDS_FILE_URL=CHANGEME
 OOS_ORDS_FILENAME=${OOS_ORDS_FILE_URL##*/}
-
-OOS_ORDS_USERNAME=adminlistener
-OOS_ORDS_PASSWORD=oracle
-
-#TOMCAT config
-#Note: If not a tar.gz then remove the additional ".*" in OOS_TC_NAME
-OOS_TC_FILE_URL=https://s3-us-west-2.amazonaws.com/orclfiles/apache-tomcat-7.0.57.tar.gz
 OOS_TC_FILENAME=${OOS_TC_FILE_URL##*/}
 OOS_TC_NAME=${OOS_TC_FILENAME%.*.*}
-
-OOS_TC_USERNAME=tomcat
-OOS_TC_PWD=oracle
-
-
-#FIREWALL Config
-#Change these to Y to allow public access to their ports
-OOS_FIREWALL_TOMCAT_YN=N
-OOS_FIREWALL_ORACLE_YN=N
-
-
-#RLWRAP: https://github.com/hanslub42/rlwrap
-OOS_RLWRAP_FILENAME=rlwrap-0.42.tar.gz
 OOS_RLWRAP_NAME=${OOS_RLWRAP_FILENAME%.*.*}
 
 #Call Validations

--- a/config.sh
+++ b/config.sh
@@ -44,8 +44,5 @@ else
   OOS_TC_NAME=${OOS_TC_FILENAME%.*}
 fi
 
-echo T0: $OOS_TC_FILE_URL
-echo T1: $OOS_TC_NAME
-
 #Call Validations
 source ./scripts/config_validation.sh


### PR DESCRIPTION
Resolves #41.

I've moved the CHANGEME properties to the top of the file, as these are the main settings that users would be changing, and that way they are easy to locate. Has the downside of not being grouped with like properties though. 

We perhaps need to also make OOS_APEX_ADMIN_EMAIL a CHANGEME property - it's easy to overlook.

Tested on CentOS 7.x