### PR TITLE
More progress towards Debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you need additional help, there is a [How-To video](http://www.oraopensource.
 
 
 # Supported OS's
-This script currently works on the following operating systems
+This script currently works on the following Linux distributions
 
 <table>
   <tr>
@@ -71,8 +71,8 @@ This script currently works on the following operating systems
     <td>7.0</td>
   </tr>
   <tr>
-    <td>Debian (pending)</td>
-    <td>7.8</td>
+    <td>Debian</td>
+    <td>8.0</td>
   </tr>
 </table>
 

--- a/build.sh
+++ b/build.sh
@@ -51,9 +51,11 @@ while [[ $# > 0 ]]; do
 done
 
 OOS_UTILS_DIR=${OOS_SOURCE_DIR}/utils
+OOS_SERVICE_CTL=${OOS_UTILS_DIR}/servicectl.sh
 OOS_LOG_DIR=${OOS_SOURCE_DIR}/logs
 OOS_INSTALL_LOG=${OOS_LOG_DIR}/install.log
 OOS_ERROR_LOG=${OOS_LOG_DIR}/error.log
+
 
 if [ "$OOS_VERBOSE_OUT" = true ]; then
   OOS_LOG_OPTIONS=" > >(tee ${OOS_INSTALL_LOG} --append) 2> >(tee ${OOS_ERROR_LOG} --append >&2)"

--- a/init.d/node4ords.conf
+++ b/init.d/node4ords.conf
@@ -1,0 +1,6 @@
+# Upstart config file for node4ords
+
+description "Node4Ords - proxy to APEX using ORDS on Tomcat"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+exec /usr/local/bin/node4ords

--- a/node4ords/node4ords
+++ b/node4ords/node4ords
@@ -1,3 +1,10 @@
 #!/bin/bash
 . /etc/node4ords.conf
-/bin/node ${APP_DIR}/${NODE_APP}
+
+#Check if node exists. Idea adapted from: http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script
+if hash node; then
+    node ${APP_DIR}/${NODE_APP}
+else
+    echo "NodeJS doesn't exist on this system." >&2
+    exit 1
+fi

--- a/oracle/chkconfig
+++ b/oracle/chkconfig
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Oracle 11gR2 XE installer chkconfig hack for Debian based Linux (by dude)
+# Debian (8) has chkconfig in the repos, but Ubuntu does not (since 12.10)
+# Only run once.
+
+echo "Simulating /sbin/chkconfig..."
+if [[ ! `tail -n1 /etc/init.d/oracle-xe | grep INIT` ]]; then
+cat >> /etc/init.d/oracle-xe <<-EOM
+#
+### BEGIN INIT INFO
+# Provides:              OracleXE
+# Required-Start:        $remote_fs $syslog
+# Required-Stop:         $remote_fs $syslog
+# Default-Start:         2 3 4 5
+# Default-Stop:          0 1 6
+# Short-Description:     Oracle 11g Express Edition
+### END INIT INFO
+EOM
+fi
+update-rc.d oracle-xe defaults 80 01

--- a/scripts/firewalld.sh
+++ b/scripts/firewalld.sh
@@ -2,7 +2,7 @@
 
 #*** FIREWALLD ***
 cd $OOS_SOURCE_DIR/tmp
-service firewalld start
+${OOS_SERVICE_CTL} stop firewalld 
 
 
 #Adding Tomcat firewall ports just in case want to test
@@ -16,7 +16,7 @@ perl -i -p -e "s/OOS_ORACLE_TNS_PORT/$OOS_ORACLE_TNS_PORT/g" oracle.xml
 perl -i -p -e "s/OOS_TOMCAT_PORT/$OOS_TOMCAT_PORT/g" tomcat.xml
 
 
-systemctl start firewalld
+${OOS_SERVICE_CTL} start firewalld
 firewall-cmd --zone=public --add-service=http --permanent
 firewall-cmd --reload
 
@@ -39,7 +39,7 @@ fi
 #Reload for any changes in above config
 firewall-cmd --reload
 
-systemctl enable firewalld
+${OOS_SERVICE_CTL} enable firewalld
 
 
 #List zone info for logs

--- a/scripts/firewalld.sh
+++ b/scripts/firewalld.sh
@@ -2,45 +2,63 @@
 
 #*** FIREWALLD ***
 cd $OOS_SOURCE_DIR/tmp
-${OOS_SERVICE_CTL} stop firewalld 
+${OOS_SERVICE_CTL} stop firewalld
+
+if hash ufw 2>/dev/null; then
+    update-rc.d firewalld disable
+
+    echo "y" | sudo ufw enable
+    ufw allow http
+    ufw allow ssh
+
+    if [ "$OOS_FIREWALL_ORACLE_YN" == "Y" ]; then
+        ufw allow ${OOS_ORACLE_TNS_PORT}/tcp
+    fi
+
+    if [ "$OOS_FIREWALL_TOMCAT_YN" == "Y" ]; then
+        ufw allow ${OOS_TOMCAT_PORT}/tcp
+    fi
+    ufw reload
+    ufw status
+
+else
+    #Adding Tomcat firewall ports just in case want to test
+    #Can copy other examples from: /usr/lib/firewalld/services/
+    cd /etc/firewalld/services
+
+    cp $OOS_SOURCE_DIR/firewalld/*.xml .
+
+    #Replace dynamic ports
+    perl -i -p -e "s/OOS_ORACLE_TNS_PORT/$OOS_ORACLE_TNS_PORT/g" oracle.xml
+    perl -i -p -e "s/OOS_TOMCAT_PORT/$OOS_TOMCAT_PORT/g" tomcat.xml
 
 
-#Adding Tomcat firewall ports just in case want to test
-#Can copy other examples from: /usr/lib/firewalld/services/
-cd /etc/firewalld/services
+    ${OOS_SERVICE_CTL} start firewalld
+    firewall-cmd --zone=public --add-service=http --permanent
+    firewall-cmd --reload
 
-cp $OOS_SOURCE_DIR/firewalld/*.xml .
+    #To add Tomcat/Oracle just run these scripts
+    #service firewalld stop
+    #service firewalld start
 
-#Replace dynamic ports
-perl -i -p -e "s/OOS_ORACLE_TNS_PORT/$OOS_ORACLE_TNS_PORT/g" oracle.xml
-perl -i -p -e "s/OOS_TOMCAT_PORT/$OOS_TOMCAT_PORT/g" tomcat.xml
+    #Note: add the --permanent for permanent usage
+    #firewall-cmd --zone=public --add-service=tomcat
+    #firewall-cmd --zone=public --remove-service=tomcat
+
+    if [ "$OOS_FIREWALL_TOMCAT_YN" == "Y" ]; then
+      firewall-cmd --zone=public --add-service=tomcat --permanent
+    fi
+
+    if [ "$OOS_FIREWALL_ORACLE_YN" == "Y" ]; then
+      firewall-cmd --zone=public --add-service=oracle --permanent
+    fi
+
+    #Reload for any changes in above config
+    firewall-cmd --reload
+
+    ${OOS_SERVICE_CTL} enable firewalld
 
 
-${OOS_SERVICE_CTL} start firewalld
-firewall-cmd --zone=public --add-service=http --permanent
-firewall-cmd --reload
-
-#To add Tomcat/Oracle just run these scripts
-#service firewalld stop
-#service firewalld start
-
-#Note: add the --permanent for permanent usage
-#firewall-cmd --zone=public --add-service=tomcat
-#firewall-cmd --zone=public --remove-service=tomcat
-
-if [ "$OOS_FIREWALL_TOMCAT_YN" == "Y" ]; then
-  firewall-cmd --zone=public --add-service=tomcat --permanent
+    #List zone info for logs
+    firewall-cmd --zone=public --list-all
 fi
-
-if [ "$OOS_FIREWALL_ORACLE_YN" == "Y" ]; then
-  firewall-cmd --zone=public --add-service=oracle --permanent
-fi
-
-#Reload for any changes in above config
-firewall-cmd --reload
-
-${OOS_SERVICE_CTL} enable firewalld
-
-
-#List zone info for logs
-firewall-cmd --zone=public --list-all

--- a/scripts/node4ords.sh
+++ b/scripts/node4ords.sh
@@ -15,7 +15,7 @@ cd ${OOS_SOURCE_DIR}
 cp node4ords/node4ords.conf /etc/node4ords.conf
 cp node4ords/node4ords /usr/local/bin/node4ords
 
-if hash systemctl; then
+if hash systemctl 2>/dev/null; then
     cp -f init.d/node4ords.service /etc/systemd/system/
     cp node4ords/rsyslog.conf /etc/rsyslog.d/node4ords.conf
     ${OOS_SERVICE_CTL} restart rsyslog

--- a/scripts/node4ords.sh
+++ b/scripts/node4ords.sh
@@ -12,11 +12,16 @@ npm install --unsafe-perm
 #Start on boot
 cd ${OOS_SOURCE_DIR}
 
-cp -f init.d/node4ords.service /etc/systemd/system/
 cp node4ords/node4ords.conf /etc/node4ords.conf
-cp node4ords/rsyslog.conf /etc/rsyslog.d/node4ords.conf
 cp node4ords/node4ords /usr/local/bin/node4ords
 
-systemctl restart rsyslog
-systemctl enable node4ords.service
-systemctl start node4ords.service
+if hash systemctl; then
+    cp -f init.d/node4ords.service /etc/systemd/system/
+    cp node4ords/rsyslog.conf /etc/rsyslog.d/node4ords.conf
+    ${OOS_SERVICE_CTL} restart rsyslog
+    ${OOS_SERVICE_CTL} enable node4ords.service
+    ${OOS_SERVICE_CTL} start node4ords.service
+else
+    cp -f init.d/node4ords.conf /etc/init/
+    ${OOS_SERVICE_CTL} start node4ords
+fi

--- a/scripts/oraclexe.sh
+++ b/scripts/oraclexe.sh
@@ -14,7 +14,7 @@ if [ -n "$(command -v yum)" ]; then
 elif [ -n "$(command -v apt-get)" ]; then
   echo; echo \* OS changes prior to install of DB \*; echo
 
-  if ! [[ -e /dev/shm]]; then
+  if ! [[ -e /dev/shm ]]; then
     mkdir /dev/shm
     mount -t tmpfs shmfs -o size=2048m /dev/shm
   fi

--- a/scripts/oraclexe.sh
+++ b/scripts/oraclexe.sh
@@ -13,9 +13,12 @@ if [ -n "$(command -v yum)" ]; then
   rpm -ivh $OOS_ORACLE_FILENAME_RPM
 elif [ -n "$(command -v apt-get)" ]; then
   echo; echo \* OS changes prior to install of DB \*; echo
-  rm -rf /dev/shm
-  mkdir /dev/shm
-  mount -t tmpfs shmfs -o size=2048m /dev/shm
+
+  if ! [[ -e /dev/shm]]; then
+    mkdir /dev/shm
+    mount -t tmpfs shmfs -o size=2048m /dev/shm
+  fi
+
   #mount -B /run/shm /dev/shm
   touch /dev/shm/.oracle-shm
   ln -s /usr/bin/awk /bin/awk

--- a/scripts/oraclexe.sh
+++ b/scripts/oraclexe.sh
@@ -14,9 +14,15 @@ if [ -n "$(command -v yum)" ]; then
 elif [ -n "$(command -v apt-get)" ]; then
   echo; echo \* OS changes prior to install of DB \*; echo
 
-  if ! [[ -e /dev/shm ]]; then
+  if ! df | grep -q "/dev/shm"; then
+    rm -rf /dev/shm
     mkdir /dev/shm
     mount -t tmpfs shmfs -o size=2048m /dev/shm
+  fi
+
+  if ! [[ -e /sbin/chkconfig ]]; then
+    cp ${OOS_SOURCE_DIR}/oracle/chkconfig /sbin/chkconfig
+    ADDED_CHKCONFIG='Y'
   fi
 
   #mount -B /run/shm /dev/shm
@@ -41,6 +47,10 @@ elif [ -n "$(command -v apt-get)" ]; then
   if [ -n "$(command -v update-rc.d)" ]; then
     update-rc.d oracle-shm defaults 01 99
     update-rc.d oracle-xe defaults
+  fi
+
+  if [[ ${ADDED_CHKCONFIG} = 'Y' ]]; then
+    rm -f /sbin/chkconfig
   fi
 
   echo; echo \* DB install complete \*; echo

--- a/scripts/ords.sh
+++ b/scripts/ords.sh
@@ -55,8 +55,6 @@ java -jar ords.war
 #Make tomcat the owner of the configuration
 chown -R tomcat.tomcat /etc/ords
 
-#Source tomcat.conf to ensure ${CATALINA_HOME} is set
-. /etc/tomcat/tomcat.conf
 rm -rf ${CATALINA_HOME}/webapps/ords/ ${CATALINA_HOME}/webapps/ords.war
 mv ords.war ${CATALINA_HOME}/webapps/
 

--- a/scripts/ords.sh
+++ b/scripts/ords.sh
@@ -6,7 +6,7 @@ ORDS_PARAMS=${ORDS_SOURCE_DIR}/params/ords_params.properties
 cd $OOS_SOURCE_DIR/tmp
 ${OOS_UTILS_DIR}/download.sh $OOS_ORDS_FILE_URL
 
-systemctl stop tomcat
+systemctl stop ${TOMCAT_SERVICE_NAME}
 
 mkdir -p ${ORDS_SOURCE_DIR}
 cd ${ORDS_SOURCE_DIR}
@@ -73,6 +73,6 @@ rm -rf apex_images/
 cp -rf ${OOS_SOURCE_DIR}/tmp/apex/images apex_images/
 
 #Make images accessible when using tomcat directly
-ln -sf /ords/apex_images/ /usr/share/tomcat/webapps/i
+ln -sf /ords/apex_images/ ${CATALINA_HOME}/webapps/i
 
-systemctl start tomcat
+systemctl start ${TOMCAT_SERVICE_NAME}

--- a/scripts/ords.sh
+++ b/scripts/ords.sh
@@ -6,7 +6,7 @@ ORDS_PARAMS=${ORDS_SOURCE_DIR}/params/ords_params.properties
 cd $OOS_SOURCE_DIR/tmp
 ${OOS_UTILS_DIR}/download.sh $OOS_ORDS_FILE_URL
 
-systemctl stop ${TOMCAT_SERVICE_NAME}
+${OOS_SERVICE_CTL} stop ${TOMCAT_SERVICE_NAME}
 
 mkdir -p ${ORDS_SOURCE_DIR}
 cd ${ORDS_SOURCE_DIR}
@@ -73,4 +73,4 @@ cp -rf ${OOS_SOURCE_DIR}/tmp/apex/images apex_images/
 #Make images accessible when using tomcat directly
 ln -sf /ords/apex_images/ ${CATALINA_HOME}/webapps/i
 
-systemctl start ${TOMCAT_SERVICE_NAME}
+${OOS_SERVICE_CTL} start ${TOMCAT_SERVICE_NAME}

--- a/scripts/ords.sh
+++ b/scripts/ords.sh
@@ -53,7 +53,7 @@ java -jar ords.war configdir /etc
 java -jar ords.war
 
 #Make tomcat the owner of the configuration
-chown -R tomcat.tomcat /etc/ords
+chown -R ${TOMCAT_USER}.${TOMCAT_USER} /etc/ords
 
 rm -rf ${CATALINA_HOME}/webapps/ords/ ${CATALINA_HOME}/webapps/ords.war
 mv ords.war ${CATALINA_HOME}/webapps/

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -38,7 +38,6 @@ elif [ -n "$(command -v apt-get)" ]; then
   alien \
   htop \
   rlwrap \
-  chkconfig \
   firewalld \
   unzip -y
 else

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -38,7 +38,8 @@ elif [ -n "$(command -v apt-get)" ]; then
   alien \
   htop \
   rlwrap \
-  chkconfig -y
+  chkconfig \
+  firewalld -y
 else
   echo; echo \* No known package manager found \*
 fi

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -39,7 +39,8 @@ elif [ -n "$(command -v apt-get)" ]; then
   htop \
   rlwrap \
   chkconfig \
-  firewalld -y
+  firewalld \
+  unzip -y
 else
   echo; echo \* No known package manager found \*
 fi

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -23,6 +23,7 @@ if [ -n "$(command -v yum)" ]; then
 elif [ -n "$(command -v apt-get)" ]; then
   echo; echo \* Installing packages with apt-get \*
   apt-get update -y
+
   apt-get install \
   unzip \
   libaio1 \
@@ -38,8 +39,7 @@ elif [ -n "$(command -v apt-get)" ]; then
   alien \
   htop \
   rlwrap \
-  firewalld \
-  unzip -y
+  firewalld -y
 else
   echo; echo \* No known package manager found \*
 fi

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -37,7 +37,8 @@ elif [ -n "$(command -v apt-get)" ]; then
   curl \
   alien \
   htop \
-  rlwrap -y
+  rlwrap \
+  chkconfig -y
 else
   echo; echo \* No known package manager found \*
 fi

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -6,6 +6,7 @@ if [ -n "$(command -v yum)" ]; then
     # Set tomcat environmental variables such as CATALINA_HOME
     . /etc/tomcat/tomcat.conf
     TOMCAT_SERVICE_NAME=tomcat.service
+    TOMCAT_USER=tomcat
 
 elif [ -n "$(command -v apt-get)" ]; then
 
@@ -13,7 +14,7 @@ elif [ -n "$(command -v apt-get)" ]; then
     # Set tomcat environmental variables such as CATALINA_HOME
     CATALINA_HOME=/var/lib/tomcat7
     TOMCAT_SERVICE_NAME=tomcat7.service
-
+    TOMCAT_USER=tomcat7
 else
 
     echo; echo \* No known package manager found \* >&2

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -5,7 +5,7 @@ if [ -n "$(command -v yum)" ]; then
 
     # Set tomcat environmental variables such as CATALINA_HOME
     . /etc/tomcat/tomcat.conf
-    TOMCAT_SERVICE_NAME=tomcat.service
+    TOMCAT_SERVICE_NAME=tomcat
     TOMCAT_USER=tomcat
 
 elif [ -n "$(command -v apt-get)" ]; then
@@ -13,7 +13,7 @@ elif [ -n "$(command -v apt-get)" ]; then
     apt-get install tomcat7 tomcat7-admin -y
     # Set tomcat environmental variables such as CATALINA_HOME
     CATALINA_HOME=/var/lib/tomcat7
-    TOMCAT_SERVICE_NAME=tomcat7.service
+    TOMCAT_SERVICE_NAME=tomcat7
     TOMCAT_USER=tomcat7
 else
 
@@ -21,7 +21,7 @@ else
     exit 1
 fi
 
-systemctl stop ${TOMCAT_SERVICE_NAME}
+${OOS_SERVICE_CTL} stop ${TOMCAT_SERVICE_NAME}
 
 #Add a user into tomcat-users.xml (/etc/tomcat/tomcat-user.xml) as defined in config.properties
 perl -i -p -e "s/<tomcat-users>/<tomcat-users>\n  <\!-- Auto generated content by http\:\/\/www.github.com\/OraOpenSource\/oraclexe-apex install scripts -->\n  <role rolename=\"manager-gui\"\/>\n  <user username=\"${OOS_TOMCAT_USERNAME}\" password=\"${OOS_TOMCAT_PASSWORD}\" roles=\"manager-gui\"\/>\n  <\!-- End auto-generated content -->/g" ${CATALINA_HOME}/conf/tomcat-users.xml
@@ -33,5 +33,5 @@ if [[ "${OOS_TOMCAT_PORT}" != 8080 ]]; then
 fi
 
 
-systemctl enable ${TOMCAT_SERVICE_NAME}
-systemctl start ${TOMCAT_SERVICE_NAME}
+${OOS_SERVICE_CTL} enable ${TOMCAT_SERVICE_NAME}
+${OOS_SERVICE_CTL} start ${TOMCAT_SERVICE_NAME}

--- a/scripts/tomcat.sh
+++ b/scripts/tomcat.sh
@@ -1,20 +1,36 @@
 #!/bin/bash
 
-#*** TOMCAT ***
-yum install tomcat tomcat-admin-webapps -y
+if [ -n "$(command -v yum)" ]; then
+    yum install tomcat tomcat-admin-webapps -y
 
-# Set tomcat environmental variables such as CATALINA_HOME
-. /etc/tomcat/tomcat.conf
+    # Set tomcat environmental variables such as CATALINA_HOME
+    . /etc/tomcat/tomcat.conf
+    TOMCAT_SERVICE_NAME=tomcat.service
+
+elif [ -n "$(command -v apt-get)" ]; then
+
+    apt-get install tomcat7 tomcat7-admin -y
+    # Set tomcat environmental variables such as CATALINA_HOME
+    CATALINA_HOME=/var/lib/tomcat7
+    TOMCAT_SERVICE_NAME=tomcat7.service
+
+else
+
+    echo; echo \* No known package manager found \* >&2
+    exit 1
+fi
+
+systemctl stop ${TOMCAT_SERVICE_NAME}
 
 #Add a user into tomcat-users.xml (/etc/tomcat/tomcat-user.xml) as defined in config.properties
 perl -i -p -e "s/<tomcat-users>/<tomcat-users>\n  <\!-- Auto generated content by http\:\/\/www.github.com\/OraOpenSource\/oraclexe-apex install scripts -->\n  <role rolename=\"manager-gui\"\/>\n  <user username=\"${OOS_TOMCAT_USERNAME}\" password=\"${OOS_TOMCAT_PASSWORD}\" roles=\"manager-gui\"\/>\n  <\!-- End auto-generated content -->/g" ${CATALINA_HOME}/conf/tomcat-users.xml
 
 # Set the preferred port
 if [[ "${OOS_TOMCAT_PORT}" != 8080 ]]; then
+
   sed -i "s/port\=\"8080\"/port\=\"${OOS_TOMCAT_PORT}\"/" ${CATALINA_HOME}/conf/server.xml
 fi
 
-#Auto start tomcat
-#tomcat service location: /usr/lib/systemd/system/tomcat.service
-systemctl enable tomcat.service
-systemctl start tomcat.service
+
+systemctl enable ${TOMCAT_SERVICE_NAME}
+systemctl start ${TOMCAT_SERVICE_NAME}

--- a/utils/servicectl.sh
+++ b/utils/servicectl.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# servicectl.sh
+# Purpose: Used to start and stop services. In order to support Ubuntu in these
+# build scripts, we need to support the fact that Ubuntu doesn't yet fully
+# support systemd - switched over in 15.04
+
+function printUsage {
+    echo "Usage: servicectl.sh [status|start|stop|restart] service" >&2
+}
+
+function arrayContains {
+    # Test if the first argument is a valid service command
+    # Function adapted from: http://stackoverflow.com/questions/3685970/check-if-an-array-contains-a-value
+    local valid_commands=(start stop restart status enable)
+    local input_command=$1
+
+    for e in "${valid_commands[@]}"; do
+        [[ ${e} == "$input_command" ]] && return 0
+    done
+
+    return 1
+}
+
+args=$#
+input_command=$1
+input_service=$2
+
+if ! arrayContains $input_command; then
+    echo "${input_command} is not a valid command" >&2
+    printUsage
+    exit 1
+fi
+
+if [[ $args -ne 2 ]]; then
+  echo "servicectl.sh: Invalid number of arguments" >&2
+  printUsage
+  exit 2
+fi
+
+if hash systemctl 2>/dev/null; then
+    systemctl ${input_command} ${input_service}
+else
+    if [[ ${input_command} == "enable" ]]; then
+        echo "enable is not supported for upstart" >&2
+        exit 3
+    fi
+    service ${input_service} ${input_command}
+fi


### PR DESCRIPTION
Addressing some differences between distros:

* Tomcat packages are named differently (and the OS users are named differently)
* Ubuntu doesn't have systemd until 15.04
* Ubuntu doesn't have the chkconfig package (used by the oracleXE installation)
* Change the way /dev/shm is handled between Ubuntu and Debian
* Add upstart script for node4ords
* Use ufw over firewalld on Ubuntu (firewalld is available, but I couldn't get the rules to properly apply in the build script)
